### PR TITLE
Do not compare compiler generated fields in tests.

### DIFF
--- a/tests/Monobjc.Tests/Generators/DynamicAssemblyHelper.cs
+++ b/tests/Monobjc.Tests/Generators/DynamicAssemblyHelper.cs
@@ -92,8 +92,11 @@ namespace Monobjc.Generators
             // TODO: Missing comparison
 
             // Fields comparison
-            FieldInfo[] fieldInfos = referenceType.GetFields(ALL);
-            Assert.AreEqual(fieldInfos.Length, testedType.GetFields(ALL).Length, prefix + "Number of Fields are different");
+            FieldInfo[] fieldInfos = referenceType.GetFields(ALL).Where(
+				f => !f.IsDefined(typeof(CompilerGeneratedAttribute), false)).ToArray();
+			FieldInfo[] testedFieldInfos = testedType.GetFields(ALL).Where(
+				f => !f.IsDefined(typeof(CompilerGeneratedAttribute), false)).ToArray();
+            Assert.AreEqual(fieldInfos.Length, testedFieldInfos.Length, prefix + "Number of Fields are different");
             foreach (FieldInfo fieldInfo in fieldInfos)
             {
                 String fieldPrefix = "Field_" + fieldInfo.Name;


### PR DESCRIPTION
After updating to Mono 3.1.2, tests failed due to extra compiler generated fields that aren't present in the dynamic generated proxies. This patch updates the test suite to ignore fields that are compiler generated.
