### PR TITLE
Update descriptor comment format.

### DIFF
--- a/native/Monobjc/sources/descriptors/descriptor-System.Boolean.mm
+++ b/native/Monobjc/sources/descriptors/descriptor-System.Boolean.mm
@@ -22,10 +22,10 @@
 //
 
 /**
- * \file    descriptor-System.Boolean.mm
+ * @file    descriptor-System.Boolean.mm
  * @brief   Contains the descriptor code to handle the System.Boolean type.
- * \author  Laurent Etiemble
- * \date    2009-2010
+ * @author  Laurent Etiemble
+ * @date    2009-2010
  */
 #include "logging.h"
 #include "marshal.h"

--- a/native/Monobjc/sources/descriptors/descriptor-System.Byte.mm
+++ b/native/Monobjc/sources/descriptors/descriptor-System.Byte.mm
@@ -22,10 +22,10 @@
 //
 
 /**
- * \file    descriptor-System.Byte.mm
+ * @file    descriptor-System.Byte.mm
  * @brief   Contains the descriptor code to handle the System.Byte type.
- * \author  Laurent Etiemble
- * \date    2009-2010
+ * @author  Laurent Etiemble
+ * @date    2009-2010
  */
 #include "logging.h"
 #include "marshal.h"

--- a/native/Monobjc/sources/descriptors/descriptor-System.Char.mm
+++ b/native/Monobjc/sources/descriptors/descriptor-System.Char.mm
@@ -22,10 +22,10 @@
 //
 
 /**
- * \file    descriptor-System.Char.mm
+ * @file    descriptor-System.Char.mm
  * @brief   Contains the descriptor code to handle the System.Char type.
- * \author  Laurent Etiemble
- * \date    2009-2010
+ * @author  Laurent Etiemble
+ * @date    2009-2010
  */
 #include "logging.h"
 #include "marshal.h"

--- a/native/Monobjc/sources/descriptors/descriptor-System.Int16.mm
+++ b/native/Monobjc/sources/descriptors/descriptor-System.Int16.mm
@@ -22,10 +22,10 @@
 //
 
 /**
- * \file    descriptor-System.Int16.mm
+ * @file    descriptor-System.Int16.mm
  * @brief   Contains the descriptor code to handle the System.Int16 type.
- * \author  Laurent Etiemble
- * \date    2009-2010
+ * @author  Laurent Etiemble
+ * @date    2009-2010
  */
 #include "logging.h"
 #include "marshal.h"

--- a/native/Monobjc/sources/descriptors/descriptor-System.Int32.mm
+++ b/native/Monobjc/sources/descriptors/descriptor-System.Int32.mm
@@ -22,10 +22,10 @@
 //
 
 /**
- * \file    descriptor-System.Int32.mm
+ * @file    descriptor-System.Int32.mm
  * @brief   Contains the descriptor code to handle the System.Int32 type.
- * \author  Laurent Etiemble
- * \date    2009-2010
+ * @author  Laurent Etiemble
+ * @date    2009-2010
  */
 #include "logging.h"
 #include "marshal.h"

--- a/native/Monobjc/sources/descriptors/descriptor-System.Int64.mm
+++ b/native/Monobjc/sources/descriptors/descriptor-System.Int64.mm
@@ -22,10 +22,10 @@
 //
 
 /**
- * \file    descriptor-System.Int64.mm
+ * @file    descriptor-System.Int64.mm
  * @brief   Contains the descriptor code to handle the System.Int64 type.
- * \author  Laurent Etiemble
- * \date    2009-2010
+ * @author  Laurent Etiemble
+ * @date    2009-2010
  */
 #include "logging.h"
 #include "marshal.h"

--- a/native/Monobjc/sources/descriptors/descriptor-System.IntPtr.mm
+++ b/native/Monobjc/sources/descriptors/descriptor-System.IntPtr.mm
@@ -22,10 +22,10 @@
 //
 
 /**
- * \file    descriptor-System.IntPtr.mm
+ * @file    descriptor-System.IntPtr.mm
  * @brief   Contains the descriptor code to handle the System.IntPtr type.
- * \author  Laurent Etiemble
- * \date    2009-2010
+ * @author  Laurent Etiemble
+ * @date    2009-2010
  */
 #include "logging.h"
 #include "marshal.h"

--- a/native/Monobjc/sources/descriptors/descriptor-System.SByte.mm
+++ b/native/Monobjc/sources/descriptors/descriptor-System.SByte.mm
@@ -22,10 +22,10 @@
 //
 
 /**
- * \file    descriptor-System.SByte.mm
+ * @file    descriptor-System.SByte.mm
  * @brief   Contains the descriptor code to handle the System.SByte type.
- * \author  Laurent Etiemble
- * \date    2009-2010
+ * @author  Laurent Etiemble
+ * @date    2009-2010
  */
 #include "logging.h"
 #include "marshal.h"

--- a/native/Monobjc/sources/descriptors/descriptor-System.UInt16.mm
+++ b/native/Monobjc/sources/descriptors/descriptor-System.UInt16.mm
@@ -22,10 +22,10 @@
 //
 
 /**
- * \file    descriptor-System.UInt16.mm
+ * @file    descriptor-System.UInt16.mm
  * @brief   Contains the descriptor code to handle the System.UInt16 type.
- * \author  Laurent Etiemble
- * \date    2009-2010
+ * @author  Laurent Etiemble
+ * @date    2009-2010
  */
 #include "logging.h"
 #include "marshal.h"

--- a/native/Monobjc/sources/descriptors/descriptor-System.UInt32.mm
+++ b/native/Monobjc/sources/descriptors/descriptor-System.UInt32.mm
@@ -22,10 +22,10 @@
 //
 
 /**
- * \file    descriptor-System.UInt32.mm
+ * @file    descriptor-System.UInt32.mm
  * @brief   Contains the descriptor code to handle the System.UInt32 type.
- * \author  Laurent Etiemble
- * \date    2009-2010
+ * @author  Laurent Etiemble
+ * @date    2009-2010
  */
 #include "logging.h"
 #include "marshal.h"

--- a/native/Monobjc/sources/descriptors/descriptor-System.UInt64.mm
+++ b/native/Monobjc/sources/descriptors/descriptor-System.UInt64.mm
@@ -22,10 +22,10 @@
 //
 
 /**
- * \file    descriptor-System.UInt64.mm
+ * @file    descriptor-System.UInt64.mm
  * @brief   Contains the descriptor code to handle the System.UInt64 type.
- * \author  Laurent Etiemble
- * \date    2009-2010
+ * @author  Laurent Etiemble
+ * @date    2009-2010
  */
 #include "logging.h"
 #include "marshal.h"


### PR DESCRIPTION
The descriptor.def file was updated to use @ instead of \ for comments. However, file, author, and date were not updated in the generated output that was checked in, so re-running generation causes these indexed files to mismatch what's in the repo without this fix.
