### PR TITLE
Add new interop methods to NSThread for invoking delegates.

### DIFF
--- a/libraries/Monobjc.AppKit/AppKit_Extensions/NSApplication.Bootstrap.cs
+++ b/libraries/Monobjc.AppKit/AppKit_Extensions/NSApplication.Bootstrap.cs
@@ -21,6 +21,7 @@
 // THE SOFTWARE.
 // 
 using System;
+using System.Threading;
 using Monobjc.Foundation;
 
 namespace Monobjc.AppKit
@@ -98,6 +99,11 @@ namespace Monobjc.AppKit
             {
                 Logger.Debug("NSApplication", "Running Application");
             }
+
+			// Install synchronization context
+			if(SynchronizationContext.Current == null || !typeof(NSThreadSynchronizationContext).IsAssignableFrom(SynchronizationContext.Current.GetType()))
+				SynchronizationContext.SetSynchronizationContext (new NSThreadSynchronizationContext(NSThread.MainThread));
+
             SharedApplication.Run();
         }
     }


### PR DESCRIPTION
This change adds convenient methods to invoke an Action delegate with optional parameter either synchronously or asynchronously on a new background thread, the main thread, or a specific thread.

Examples:
NSThread.StartNewThread (() => DoSomething());
NSThread.MainThread.Invoke (() => DoSomething());
myThread.Invoke (() => DoSomething());

This commit also removes the redundant and verbose DetachNewThreadSelectorToTargetWithObject overload.

Finally, this commit adds and installs NSThreadSynchronizationContext.
