### PR TITLE
Raise a managed exception if the Class was not found during construction.

### DIFF
--- a/libraries/Monobjc/Id.cs
+++ b/libraries/Monobjc/Id.cs
@@ -41,6 +41,8 @@ namespace Monobjc
 		{
 			this.owner = true;
 			Class cls = Class.Get (this.GetType ());
+			if (cls == null)
+				throw new NullReferenceException("Class not registered for type: " + this.GetType().FullName);
 			this.NativePointer = ObjectiveCRuntime.SendMessage<IntPtr> (cls, "alloc");
 			this.NativePointer = ObjectiveCRuntime.SendMessage<IntPtr> (this, "init");
 		}
@@ -64,6 +66,8 @@ namespace Monobjc
 		{
 			this.owner = true;
 			Class cls = Class.Get (this.GetType ());
+			if (cls == null)
+				throw new NullReferenceException("Class not registered for type: " + this.GetType().FullName);
 			this.NativePointer = ObjectiveCRuntime.SendMessage<IntPtr> (cls, "alloc");
 			this.NativePointer = ObjectiveCRuntime.SendMessageVarArgs<IntPtr> (this, selector, firstParameter, otherParameters);
 		}


### PR DESCRIPTION
Previously the Id constructor might send a null pointer through SendMessage which was harder to debug.
