### PR TITLE
Register all ObjectiveCClass types in an assembly.

### DIFF
--- a/libraries/Monobjc/ObjectiveCRuntime.cs
+++ b/libraries/Monobjc/ObjectiveCRuntime.cs
@@ -174,10 +174,10 @@ namespace Monobjc
 				List<Type> classes = new List<Type> ();
 				List<Type> categories = new List<Type> ();
 
-				// 1. Scan all exported types to extract potential candidates for:
+				// 1. Scan all types to extract potential candidates for:
 				//    - Class definitions
 				//    - Category definitions
-				foreach (Type type in assembly.GetExportedTypes()) {
+				foreach (Type type in assembly.GetTypes()) {
 					// Test for the ObjectiveCClass attribute
 					ObjectiveCClassAttribute classAttribute = Attribute.GetCustomAttribute (type, typeof(ObjectiveCClassAttribute), false) as ObjectiveCClassAttribute;
 					if (classAttribute != null) {


### PR DESCRIPTION
Previously only exported (e.g. public) types were registered. However, it is sometimes useful to register non-public Mono types with ObjectiveC for interop purposes while keeping the Mono type hidden from API consumers.
