### PR TITLE
Use the ASL logging facility instead of printing to standard output.

### DIFF
--- a/native/Monobjc/sources/logging.mm
+++ b/native/Monobjc/sources/logging.mm
@@ -28,6 +28,7 @@
  * @date    2009-2013
  */
 #include <asl.h>
+#include <pthread.h>
 #include "logging.h"
 
 /** @brief  Holds the current log level. */
@@ -110,7 +111,12 @@ void monobjc_log(MonobjcLogLevel log_level, MonobjcLogDomain domain, const char 
         char *msg;
         vasprintf(&msg, format, args);
         if (msg != NULL) {
-            asl_vlog(NULL, monobjc_aslmsg, level, format, args);
+            int domain_id = 0;
+            MonoDomain *domain = mono_domain_get();
+            if (domain != NULL) {
+                domain_id = mono_domain_get_id(domain);
+            }
+            asl_log(NULL, monobjc_aslmsg, level, "[Domain #%d - Thread #%u] %s", domain_id, pthread_mach_thread_np(pthread_self()), msg);
             free(msg);
         }
         
@@ -140,7 +146,12 @@ void monobjc_logv(MonobjcLogLevel log_level, MonobjcLogDomain domain, const char
         char *msg;
         vasprintf(&msg, format, args);
         if (msg != NULL) {
-            asl_vlog(NULL, monobjc_aslmsg, level, format, args);
+            int domain_id = 0;
+            MonoDomain *domain = mono_domain_get();
+            if (domain != NULL) {
+                domain_id = mono_domain_get_id(domain);
+            }
+            asl_log(NULL, monobjc_aslmsg, level, "[Domain #%d - Thread #%u] %s", domain_id, pthread_mach_thread_np(pthread_self()), msg);
             free(msg);
         }
     }


### PR DESCRIPTION
The logs now appear in the Console application.
