### PR TITLE
Fix SecurityInterface.Tests build in csproj.

### DIFF
--- a/tests/Monobjc.SecurityInterface.Tests/Monobjc.SecurityInterface.Tests.csproj
+++ b/tests/Monobjc.SecurityInterface.Tests/Monobjc.SecurityInterface.Tests.csproj
@@ -76,14 +76,6 @@
       <Project>{DAB53EE6-F548-4FAC-892D-D2EB2386C4A4}</Project>
       <Name>Monobjc.Foundation</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\libraries\Monobjc.Security\Monobjc.Security.csproj">
-      <Project>{D8948503-4D3A-4AE2-8C90-897C5AE18884}</Project>
-      <Name>Monobjc.Security</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\libraries\Monobjc.SecurityFoundation\Monobjc.SecurityFoundation.csproj">
-      <Project>{B49863BB-D088-4AAC-8D2F-D8726F27A930}</Project>
-      <Name>Monobjc.SecurityFoundation</Name>
-    </ProjectReference>
     <ProjectReference Include="..\..\libraries\Monobjc.SecurityInterface\Monobjc.SecurityInterface.csproj">
       <Project>{DA344DE8-2FA3-4F0B-A898-3360BF4D4A38}</Project>
       <Name>Monobjc.SecurityInterface</Name>


### PR DESCRIPTION
The project would not build because the explicit reference to Monobjc.Security and Monobjc.SecurityFoundation conflicted with the implicit references from Monobjc.SecurityInterface.
