### PR TITLE
Remove NSPinnedString method and optimize NSString.ToString().

### DIFF
--- a/libraries/Monobjc.Foundation/Foundation_Extensions/NSString.Interop.cs
+++ b/libraries/Monobjc.Foundation/Foundation_Extensions/NSString.Interop.cs
@@ -21,6 +21,7 @@
 // THE SOFTWARE.
 // 
 using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace Monobjc.Foundation
@@ -30,21 +31,9 @@ namespace Monobjc.Foundation
         /// <summary>
         /// Empty string
         /// </summary>
-        public static readonly NSString Empty = NSPinnedString(System.String.Empty);
-
-        /// <summary>
-        /// Returns an retained instance of NSString.
-        /// </summary>
-        /// <param name="value">The value.</param>
-        public static NSString NSPinnedString(String value)
+        public static NSString Empty
         {
-            if (value == null)
-            {
-                throw new ArgumentNullException("value");
-            }
-            NSString str = new NSString(value);
-            str.Retain(); // TODO: Seems to be not needed, isn't it ?
-            return str;
+            get { return System.String.Empty; }
         }
 
         /// <summary>
@@ -64,7 +53,7 @@ namespace Monobjc.Foundation
         ///</returns>
         public override String ToString()
         {
-            return Marshal.PtrToStringAuto(this.UTF8String);
+            return ToStringInternal(this.NativePointer);
         }
 
         /// <summary>
@@ -91,7 +80,7 @@ namespace Monobjc.Foundation
         /// <returns>The result of the conversion.</returns>
         public static implicit operator String(NSString value)
         {
-            return value != null ? value.ToString() : null;
+            return value != null ? ToStringInternal(value.NativePointer) : null;
         }
 
         /// <summary>
@@ -116,5 +105,11 @@ namespace Monobjc.Foundation
         {
             return (@string == null || @string.IsEqualToString(NSString.String));
         }
+
+        /// <summary>
+        /// Internal call to convert a <see cref="Monobjc.Foundation.NSString"/> object to a <see cref="System.String"/> object.
+        /// </summary>
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        public extern static String ToStringInternal (IntPtr ptr);
     }
 }

--- a/native/Monobjc/Monobjc.xcodeproj/project.pbxproj
+++ b/native/Monobjc/Monobjc.xcodeproj/project.pbxproj
@@ -165,6 +165,10 @@
 		4D7C2B2F141D69C1008CF2AD /* support-os.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D7C2B2E141D69C1008CF2AD /* support-os.h */; };
 		4D7C2B31141D69CE008CF2AD /* support-os.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4D7C2B30141D69CE008CF2AD /* support-os.mm */; };
 		4D7C2B32141D69CE008CF2AD /* support-os.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4D7C2B30141D69CE008CF2AD /* support-os.mm */; };
+		4D8371CB17C680990065053F /* icalls-Monobjc.Foundation.NSString.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4D8371CA17C680990065053F /* icalls-Monobjc.Foundation.NSString.mm */; };
+		4D8371CC17C680990065053F /* icalls-Monobjc.Foundation.NSString.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4D8371CA17C680990065053F /* icalls-Monobjc.Foundation.NSString.mm */; };
+		4D8371CD17C680990065053F /* icalls-Monobjc.Foundation.NSString.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4D8371CA17C680990065053F /* icalls-Monobjc.Foundation.NSString.mm */; };
+		4D8371CE17C680990065053F /* icalls-Monobjc.Foundation.NSString.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4D8371CA17C680990065053F /* icalls-Monobjc.Foundation.NSString.mm */; };
 		4D9CC07D11568E090027FF52 /* icalls-Monobjc.ObjectiveCEncoding.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4D9CC07C11568E090027FF52 /* icalls-Monobjc.ObjectiveCEncoding.mm */; };
 		4D9CC07E11568E090027FF52 /* icalls-Monobjc.ObjectiveCEncoding.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4D9CC07C11568E090027FF52 /* icalls-Monobjc.ObjectiveCEncoding.mm */; };
 		4D9E554617898AB400D7C497 /* blocks.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4D9E554517898AB400D7C497 /* blocks.mm */; };
@@ -390,6 +394,7 @@
 		4D791AF61158037C0062C7E0 /* logging.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = logging.mm; path = sources/logging.mm; sourceTree = "<group>"; };
 		4D7C2B2E141D69C1008CF2AD /* support-os.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "support-os.h"; path = "sources/support-os.h"; sourceTree = "<group>"; };
 		4D7C2B30141D69CE008CF2AD /* support-os.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = "support-os.mm"; path = "sources/support-os.mm"; sourceTree = "<group>"; };
+		4D8371CA17C680990065053F /* icalls-Monobjc.Foundation.NSString.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = "icalls-Monobjc.Foundation.NSString.mm"; path = "sources/icalls/icalls-Monobjc.Foundation.NSString.mm"; sourceTree = "<group>"; };
 		4D9CC07C11568E090027FF52 /* icalls-Monobjc.ObjectiveCEncoding.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = "icalls-Monobjc.ObjectiveCEncoding.mm"; path = "sources/icalls/icalls-Monobjc.ObjectiveCEncoding.mm"; sourceTree = "<group>"; };
 		4D9E554517898AB400D7C497 /* blocks.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = blocks.mm; path = sources/blocks.mm; sourceTree = "<group>"; };
 		4DA5213F1159690A007C19C3 /* descriptor.def */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = descriptor.def; path = sources/descriptors/descriptor.def; sourceTree = "<group>"; };
@@ -699,6 +704,7 @@
 			children = (
 				4D447491115F7A63002B810F /* icalls-Monobjc.Block.mm */,
 				4DED6A8C1154C8C500AF687B /* icalls-Monobjc.Class.mm */,
+				4D8371CA17C680990065053F /* icalls-Monobjc.Foundation.NSString.mm */,
 				4DED6A8D1154C8C500AF687B /* icalls-Monobjc.Id.mm */,
 				4DFDB18A115BC51B00F345DA /* icalls-Monobjc.Logger.mm */,
 				4D9CC07C11568E090027FF52 /* icalls-Monobjc.ObjectiveCEncoding.mm */,
@@ -1157,6 +1163,7 @@
 				4D6781B31769980E00B8BBE7 /* support-ffi.mm in Sources */,
 				4D6781B41769980E00B8BBE7 /* support-os.mm in Sources */,
 				4D9E554717898AB400D7C497 /* blocks.mm in Sources */,
+				4D8371CC17C680990065053F /* icalls-Monobjc.Foundation.NSString.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1204,6 +1211,7 @@
 				4D6781EB1769981900B8BBE7 /* support-ffi.mm in Sources */,
 				4D6781EC1769981900B8BBE7 /* support-os.mm in Sources */,
 				4D9E554917898AB400D7C497 /* blocks.mm in Sources */,
+				4D8371CE17C680990065053F /* icalls-Monobjc.Foundation.NSString.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1258,6 +1266,7 @@
 				4D5AE8AC118DB2C100226780 /* support-ffi.mm in Sources */,
 				4D7C2B31141D69CE008CF2AD /* support-os.mm in Sources */,
 				4D9E554617898AB400D7C497 /* blocks.mm in Sources */,
+				4D8371CB17C680990065053F /* icalls-Monobjc.Foundation.NSString.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1305,6 +1314,7 @@
 				4D5AE8AB118DB2C100226780 /* support-ffi.mm in Sources */,
 				4D7C2B32141D69CE008CF2AD /* support-os.mm in Sources */,
 				4D9E554817898AB400D7C497 /* blocks.mm in Sources */,
+				4D8371CD17C680990065053F /* icalls-Monobjc.Foundation.NSString.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/native/Monobjc/sources/descriptors/descriptor-System.String.mm
+++ b/native/Monobjc/sources/descriptors/descriptor-System.String.mm
@@ -63,7 +63,7 @@ static MonoObject *__marshal_from_native_for_System_String(MonobjcTypeDescriptor
 }
 
 /**
- * @brief   Marshal a System.String object to its native value.
+ * @brief   Marshal a System.String object to its native value. This string is passed using the UTF-8 encoding.
  * @param   descriptor  The descriptor.
  * @param   obj         The managed object.
  * @param   ptr         The pointer to the storage zone that will contain the native object.

--- a/native/Monobjc/sources/icalls.def
+++ b/native/Monobjc/sources/icalls.def
@@ -108,3 +108,9 @@ ICALL("GetOSVersion",                   OSVersion,      icall_Monobjc_Runtime_Pl
 ICALL("Is64Bits",                       boolean_t,      icall_Monobjc_Runtime_Platform_Is64Bits,                    (void))
 ICALL("IsBigEndian",                    boolean_t,      icall_Monobjc_Runtime_Platform_IsBigEndian,                 (void))
 #undef ICALLTYPE
+
+#pragma mark ----- Internal Calls for Monobjc.Foundation.NSString -----
+
+#define ICALLTYPE   "Monobjc.Foundation.NSString"
+ICALL("ToStringInternal",               MonoString *,   icall_Monobjc_Foundation_NSString_ToString,                 (void *ptr))
+#undef ICALLTYPE

--- a/native/Monobjc/sources/icalls/icalls-Monobjc.Foundation.NSString.mm
+++ b/native/Monobjc/sources/icalls/icalls-Monobjc.Foundation.NSString.mm
@@ -1,0 +1,52 @@
+//
+// This file is part of Monobjc, a .NET/Objective-C bridge
+// Copyright (C) 2007-2013 - Laurent Etiemble
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+/**
+ * @file    icalls-Monobjc.Foundation.NSString.mm
+ * @brief   Contains the internal calls for the Monobjc.Foundation.NSString type.
+ * @author  Laurent Etiemble <laurent.etiemble@monobjc.net>
+ * @date    2013
+ */
+#include "logging.h"
+#include "support-mono.h"
+
+#pragma mark ----- Internal Calls -----
+
+/**
+ * @brief   Internal call to convert a NSString to a MonoString.
+ * @param   ptr     The pointer to the NSString object or NULL.
+ * @return  Return a MonoString object if the NSString object is defined and can be converted; NULL otherwise.
+ */
+MonoString *icall_Monobjc_Foundation_NSString_ToString(void *ptr) {
+    if (!ptr) {
+        return NULL;
+    }
+    
+    NSString *obj = (NSString *)ptr;
+    mono_unichar2 *data = (mono_unichar2 *) [obj cStringUsingEncoding:NSUTF16StringEncoding];
+    if (!data) {
+        LOG_WARNING(MONOBJC_DOMAIN_GENERAL, "Cannot convert NSString to MonoString at %p", ptr);
+        return NULL;
+    }
+    return mono_string_from_utf16(data);
+}

--- a/tests/Monobjc.Foundation.Tests/NSLocaleTests.cs
+++ b/tests/Monobjc.Foundation.Tests/NSLocaleTests.cs
@@ -52,6 +52,7 @@ namespace Monobjc.Foundation
 			CultureInfo info;
 			
 			locale = new NSLocale("en");
+            Assert.IsNotNull(locale.LocaleIdentifier, "LocaleIdentifier should not be null");
 			Assert.AreEqual("en", locale.LocaleIdentifier.ToString(), "Identifier should be equal");
 			Check (locale);
 

--- a/tests/Monobjc.Foundation.Tests/NSNotificationTests.cs
+++ b/tests/Monobjc.Foundation.Tests/NSNotificationTests.cs
@@ -85,7 +85,7 @@ namespace Monobjc.Foundation
     {
         public static Class MyListenerClass = Class.Get(typeof (MyListener));
 		
-		public static readonly String SELECTOR_NOTIFICATION = new NSString("SELECTOR_NOTIFICATION");
+        public const String SELECTOR_NOTIFICATION = "SELECTOR_NOTIFICATION";
 		
         public MyListener()
         {

--- a/tests/Monobjc.Foundation.Tests/NSNotificationTests.cs
+++ b/tests/Monobjc.Foundation.Tests/NSNotificationTests.cs
@@ -85,7 +85,7 @@ namespace Monobjc.Foundation
     {
         public static Class MyListenerClass = Class.Get(typeof (MyListener));
 		
-		public static readonly NSString SELECTOR_NOTIFICATION = NSString.NSPinnedString("SELECTOR_NOTIFICATION");
+		public static readonly String SELECTOR_NOTIFICATION = new NSString("SELECTOR_NOTIFICATION");
 		
         public MyListener()
         {

--- a/tests/Monobjc.Foundation.Tests/NSStringTests.cs
+++ b/tests/Monobjc.Foundation.Tests/NSStringTests.cs
@@ -71,6 +71,52 @@ namespace Monobjc.Foundation
         }
 
         [Test]
+        public void TestEncoding()
+        {
+            // Check ASCII characters
+            NSString str1 = NSString.StringWithUTF8String("abcdefghijklmnopqrstuvwxyz");
+            Check(str1, 26);
+            String tostr1 = str1.ToString();
+            Assert.AreEqual(26, tostr1.Length, "String has the wrong size");
+            Assert.AreEqual("abcdefghijklmnopqrstuvwxyz", tostr1, "String must match");
+
+            // Check Cyrillic characters
+            NSString str2 = NSString.StringWithUTF8String("АБВГДЕЖЗИЙКЛМНОП");
+            Check(str2, 16);
+            String tostr2 = str2.ToString();
+            Assert.AreEqual(16, tostr2.Length, "String has the wrong size");
+            Assert.AreEqual("АБВГДЕЖЗИЙКЛМНОП", tostr2, "String must match");
+            
+            // Check Devanagari characters
+            NSString str3 = NSString.StringWithUTF8String("ऑऒओऔ");
+            Check(str3, 4);
+            String tostr3 = str3.ToString();
+            Assert.AreEqual(4, tostr3.Length, "String has the wrong size");
+            Assert.AreEqual("ऑऒओऔ", tostr3, "String must match");
+
+            // Check Cherokee characters
+            NSString str4 = NSString.StringWithUTF8String("ᎰᎱᎲᎳᎴ");
+            Check(str4, 5);
+            String tostr4 = str4.ToString();
+            Assert.AreEqual(5, tostr4.Length, "String has the wrong size");
+            Assert.AreEqual("ᎰᎱᎲᎳᎴ", tostr4, "String must match");
+            
+            // Check Mathematical Symbols characters
+            NSString str5 = NSString.StringWithUTF8String("∀∁∂∃∄∅∆∇∈∉∊∋");
+            Check(str5, 12);
+            String tostr5 = str5.ToString();
+            Assert.AreEqual(12, tostr5.Length, "String has the wrong size");
+            Assert.AreEqual("∀∁∂∃∄∅∆∇∈∉∊∋", tostr5, "String must match");
+
+            // Check CJK Unified Ideographs characters
+            NSString str6 = NSString.StringWithUTF8String("瀀瀁瀂瀃瀄瀅瀆瀇瀈瀉瀊瀋瀌瀍");
+            Check(str6, 14);
+            String tostr6 = str6.ToString();
+            Assert.AreEqual(14, tostr6.Length, "String has the wrong size");
+            Assert.AreEqual("瀀瀁瀂瀃瀄瀅瀆瀇瀈瀉瀊瀋瀌瀍", tostr6, "String must match");
+        }
+
+        [Test]
         public void TestExceptions()
         {
             Assert.Throws<ObjectiveCMessagingException>(() => { NSString.StringWithUTF8String(null); });
@@ -80,7 +126,7 @@ namespace Monobjc.Foundation
         {
             Assert.IsNotNull(str, "String cannot be null");
             Assert.AreNotEqual(IntPtr.Zero, str.NativePointer, "Native pointer cannot be null");
-            Assert.AreEqual(length, str.Length, "String has wrong size");
+            Assert.AreEqual(length, str.Length, "String has the wrong size");
         }
     }
 }


### PR DESCRIPTION
Optimize ToString method by skipping the UTF-8 conversion and by an internal call.
Add Unicode conversion tests.
