### PR TITLE
Switch to transient DynamicAssembly to support sandbox

### DIFF
--- a/libraries/Monobjc/Generators/DynamicAssembly.cs
+++ b/libraries/Monobjc/Generators/DynamicAssembly.cs
@@ -36,18 +36,24 @@ namespace Monobjc.Generators
 		private readonly String moduleName;
 		private readonly ModuleBuilder module;
 
-		public DynamicAssembly (String assemblyName, String moduleName)
-		{
-			this.assemblyName = assemblyName;
-			this.moduleName = moduleName;
+        public DynamicAssembly (String assemblyName, String moduleName, AssemblyBuilderAccess access = AssemblyBuilderAccess.RunAndSave)
+        {
+            this.assemblyName = assemblyName;
+            this.moduleName = moduleName;
 
-			// Define dynamic assembly
-			AssemblyName name = new AssemblyName {Name = this.assemblyName, Version = Assembly.GetExecutingAssembly().GetName().Version};
-			this.assembly = AppDomain.CurrentDomain.DefineDynamicAssembly (name, AssemblyBuilderAccess.RunAndSave);
+            // Define dynamic assembly
+            AssemblyName name = new AssemblyName {Name = this.assemblyName, Version = Assembly.GetExecutingAssembly().GetName().Version};
+            this.assembly = AppDomain.CurrentDomain.DefineDynamicAssembly (name, access);
 
-			// Define dynamic module
-			this.module = this.assembly.DefineDynamicModule (this.moduleName, this.assemblyName + ".dll");
-		}
+            // Define dynamic module
+            if (access == AssemblyBuilderAccess.RunAndSave || access == AssemblyBuilderAccess.Save) {
+                // Persistent
+                this.module = this.assembly.DefineDynamicModule (this.moduleName, this.assemblyName + ".dll");
+            } else {
+                // Transient
+                this.module = this.assembly.DefineDynamicModule (this.moduleName);
+            }
+        }
 
 		public String Save ()
 		{


### PR DESCRIPTION
DefineDynamicAssembly relies on GetCurrentDirectory() which will fail in the Mac sandbox. NSHomeDirectory() must be used instead. Rather than persisting to disk, this patch makes DynamicAssembly transient when used by the runtime.
